### PR TITLE
Added login screen to verify participant emails with roster

### DIFF
--- a/app/groupformer/min_iteration2/templates/main/login.html
+++ b/app/groupformer/min_iteration2/templates/main/login.html
@@ -20,9 +20,15 @@
       
       <div class="spacer"></div>
       
+      
+      
       <div class="row">
         <main role="main" class="col-8 mx-auto px-4">
-          <form class="needs-validation" action='' method="post" enctype="multipart/form-data"  id="login" novalidate>
+        {% if error %}
+          <div class="alert alert-primary" role="alert" visibility=hidden>Email not connected to this section</div>
+        {% endif %}
+          <form class="needs-validation" action='validate_login' method="post" enctype="multipart/form-data" novalidate>
+            {% csrf_token %}
             <div class="custom-form-box">
               <label for="email">Email</label>
               <input type="text" class="form-control" id="email" required>

--- a/app/groupformer/min_iteration2/templates/main/login.html
+++ b/app/groupformer/min_iteration2/templates/main/login.html
@@ -1,5 +1,66 @@
-
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
-{{ groupformer.prof_name }}
+  <head>
+    <meta charset="utf-8">
+    <!-- Custom CSS file -->
+    <link rel="stylesheet" type="text/css" href="{% static 'main/style.css' %}">
+    <!-- Bootstrap CDN -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+      <title>Log into {{groupformer.class_section}} by {{ groupformer.prof_name }}</title>
+  
+  </head>
+  <body>
+  
+  <div id="page-container"> <!-- Same layout as response_screen.html -->
+    <div id="container-fluid">
+      <div class="row">
+        <h1 class="display-4 text-center mx-auto d-block">Log into {{groupformer.class_section}} by {{ groupformer.prof_name }}</h1>
+      </div>
+      
+      <div class="spacer"></div>
+      
+      <div class="row">
+        <main role="main" class="col-8 mx-auto px-4">
+          <form class="needs-validation" action='' method="post" enctype="multipart/form-data"  id="login" novalidate>
+            <div class="custom-form-box">
+              <label for="email">Email</label>
+              <input type="text" class="form-control" id="email" required>
+                <div class="invalid-feedback">
+                  Must complete this field.
+                </div>
+            </div>
+            <br>
+            <button type="submit" class="btn btn-primary">Submit</button>
+          </form>
+        </main>
+      </div>
+    </div>
+  </div>
+  
+  
+  <script>
+            // Example starter JavaScript for disabling form submissions if there are invalid fields
+            (function() {
+                'use strict';
+                window.addEventListener('load', function() {
+                    // Fetch all the forms we want to apply custom Bootstrap validation styles to
+                    var forms = document.getElementsByClassName('needs-validation');
+                    // Loop over them and prevent submission
+                    var validation = Array.prototype.filter.call(forms, function(form) {
+                    form.addEventListener('submit', function(event) {
+                        if (form.checkValidity() === false) {
+                            event.preventDefault();
+                            event.stopPropagation();
+                        }
+                        form.classList.add('was-validated');
+                    }, false);
+                    });
+                }, false);
+            })();
+        </script>
+
+        <!-- Bootstrap Scripts (STAY AT BOTTOM) -->
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
+  </body>
 </html>

--- a/app/groupformer/min_iteration2/templates/main/login.html
+++ b/app/groupformer/min_iteration2/templates/main/login.html
@@ -25,7 +25,7 @@
       <div class="row">
         <main role="main" class="col-8 mx-auto px-4">
         {% if error %}
-          <div class="alert alert-danger" role="alert" visibility=hidden>Email not connected to this section</div>
+          <div class="alert alert-danger" id="bad-email" role="alert" visibility=hidden>Email not connected to this section</div>
         {% endif %}
           <form class="needs-validation" action='login' method="post" enctype="multipart/form-data" novalidate>
             {% csrf_token %}
@@ -37,7 +37,7 @@
                 </div>
             </div>
             <br>
-            <button type="submit" class="btn btn-primary">Submit</button>
+            <button type="submit" id="login-submit" class="btn btn-primary">Submit</button>
           </form>
         </main>
       </div>

--- a/app/groupformer/min_iteration2/templates/main/login.html
+++ b/app/groupformer/min_iteration2/templates/main/login.html
@@ -1,0 +1,5 @@
+
+<!DOCTYPE html>
+<html lang="en">
+{{ groupformer.prof_name }}
+</html>

--- a/app/groupformer/min_iteration2/templates/main/login.html
+++ b/app/groupformer/min_iteration2/templates/main/login.html
@@ -31,7 +31,7 @@
             {% csrf_token %}
             <div class="custom-form-box">
               <label for="email">Email</label>
-              <input type="text" class="form-control" id="email" required>
+              <input type="text" class="form-control" name="email" required>
                 <div class="invalid-feedback">
                   Must complete this field.
                 </div>

--- a/app/groupformer/min_iteration2/templates/main/login.html
+++ b/app/groupformer/min_iteration2/templates/main/login.html
@@ -25,9 +25,9 @@
       <div class="row">
         <main role="main" class="col-8 mx-auto px-4">
         {% if error %}
-          <div class="alert alert-primary" role="alert" visibility=hidden>Email not connected to this section</div>
+          <div class="alert alert-danger" role="alert" visibility=hidden>Email not connected to this section</div>
         {% endif %}
-          <form class="needs-validation" action='validate_login' method="post" enctype="multipart/form-data" novalidate>
+          <form class="needs-validation" action='login' method="post" enctype="multipart/form-data" novalidate>
             {% csrf_token %}
             <div class="custom-form-box">
               <label for="email">Email</label>

--- a/app/groupformer/min_iteration2/templates/main/loginerror.html
+++ b/app/groupformer/min_iteration2/templates/main/loginerror.html
@@ -1,0 +1,3 @@
+<html>
+No GroupFormer with that primary key
+</html>

--- a/app/groupformer/min_iteration2/templates/main/loginerror.html
+++ b/app/groupformer/min_iteration2/templates/main/loginerror.html
@@ -1,3 +1,6 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
+<body>
 No GroupFormer with that primary key
+</body>
 </html>

--- a/app/groupformer/min_iteration2/tests.py
+++ b/app/groupformer/min_iteration2/tests.py
@@ -22,9 +22,48 @@ class MinIteration2ResponseScreenTests(TestCase):
         self.assertContains(response, "How comfortable are you with front-end?")
         self.assertContains(response, "How comfortable are you with back-end?")
 
-
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from selenium.webdriver.firefox.webdriver import WebDriver
+from selenium.common.exceptions import NoSuchElementException
+from dbtools.models import *
+
+class LoginScreenTest(StaticLiveServerTestCase):
+    @classmethod
+    def setUp(cls):
+        gf = addGroupFormer("Ben Johnson","bjohn@umbc.edu","CMSC 447-01")
+        gf.addParticipant("John Beachy","johnny@niu.edu")
+        
+        super().setUpClass()
+        cls.selenium = WebDriver()
+        cls.selenium.implicitly_wait(0.5)
+    
+    @classmethod
+    def tearDownClass(cls):
+        cls.selenium.quit()
+        super().tearDownClass()
+    
+    def test_login(self):
+        self.selenium.get('%s%s' % (self.live_server_url, '/min_iteration2/response_screen/1/login'))
+        
+        #No alert on first look
+        with self.assertRaises(NoSuchElementException):
+            alert = self.selenium.find_element_by_id('bad-email')
+        
+        email = self.selenium.find_element_by_name('email')
+        email.send_keys("nonsense@non.sense")
+        submit = self.selenium.find_element_by_id('login-submit')
+        submit.click()
+        #Once an incorrect email is entered, an alert is shown
+        alert = self.selenium.find_element_by_id('bad-email')
+        
+        email = self.selenium.find_element_by_name('email')
+        email.send_keys("johnny@niu.edu")
+        submit = self.selenium.find_element_by_id('login-submit')
+        submit.click()
+        
+        #Should be redirected to response screen
+        self.assertTrue(self.selenium.current_url.endswith("/min_iteration2/response_screen/"))
+        
 
 class SeleniumGroupformerList(StaticLiveServerTestCase):
 

--- a/app/groupformer/min_iteration2/urls.py
+++ b/app/groupformer/min_iteration2/urls.py
@@ -8,8 +8,6 @@ urlpatterns = [
     #path('response_screen/<int:pk>/', views.FormResponseView.as_view(), name='form_response')  Idea for using Form as a model for DetailView
     
     path('response_screen/<int:groupformer_id>/login', views.login_group, name='login'),
-    path('response_screen/<int:groupformer_id>/validate_login', views.validate_login, name='validate_login'),
-
     path('groupformer_list/', views.groupformer_list, name='groupformer_list'),
     path('groupformer_list/sample_groups/<int:groupformer_id>', views.sample_groups, name='sample_groups'),
 ]

--- a/app/groupformer/min_iteration2/urls.py
+++ b/app/groupformer/min_iteration2/urls.py
@@ -6,6 +6,7 @@ app_name = 'min_iteration2'
 urlpatterns = [
     path('response_screen/', views.response_screen, name='response_screen'),
     #path('response_screen/<int:pk>/', views.FormResponseView.as_view(), name='form_response')  Idea for using Form as a model for DetailView
+    path('response_screen/<int:groupformer_id>/login', views.login_group, name='login'),
 
     path('groupformer_list/', views.groupformer_list, name='groupformer_list'),
     path('groupformer_list/sample_groups/<int:groupformer_id>', views.sample_groups, name='sample_groups'),

--- a/app/groupformer/min_iteration2/urls.py
+++ b/app/groupformer/min_iteration2/urls.py
@@ -6,7 +6,9 @@ app_name = 'min_iteration2'
 urlpatterns = [
     path('response_screen/', views.response_screen, name='response_screen'),
     #path('response_screen/<int:pk>/', views.FormResponseView.as_view(), name='form_response')  Idea for using Form as a model for DetailView
+    
     path('response_screen/<int:groupformer_id>/login', views.login_group, name='login'),
+    path('response_screen/<int:groupformer_id>/validate_login', views.validate_login, name='validate_login'),
 
     path('groupformer_list/', views.groupformer_list, name='groupformer_list'),
     path('groupformer_list/sample_groups/<int:groupformer_id>', views.sample_groups, name='sample_groups'),

--- a/app/groupformer/min_iteration2/views.py
+++ b/app/groupformer/min_iteration2/views.py
@@ -62,6 +62,15 @@ def login_group(request, groupformer_id):
     print(repr(gf))
     return render(request, 'main/login.html', {"groupformer" : gf})
 
+def validate_login(request, groupformer_id):
+    #Validate the login
+    gfs = GroupFormer.objects.filter(pk=groupformer_id)
+    if len(gfs) == 0:
+        return render(request, 'main/loginerror.html')
+    gf = gfs[0]
+    
+    
+
 def sample_groups(request, groupformer_id):
     # Create arbitrary sample groups for testing the front-end
     sections = {}

--- a/app/groupformer/min_iteration2/views.py
+++ b/app/groupformer/min_iteration2/views.py
@@ -54,25 +54,20 @@ def groupformer_list(request):
     return render(request, 'main/groupformer_list.html', {"groupformers": groupformers})
 
 def login_group(request, groupformer_id):
-    # Log into the groupformer
     gfs = GroupFormer.objects.filter(pk=groupformer_id)
     if len(gfs) == 0:
         return render(request, 'main/loginerror.html')
     gf = gfs[0]
-    print(repr(gf))
-    return render(request, 'main/login.html', {"groupformer" : gf})
-
-def validate_login(request, groupformer_id):
-    #Validate the login
-    gfs = GroupFormer.objects.filter(pk=groupformer_id)
-    if len(gfs) == 0:
-        return render(request, 'main/loginerror.html')
-    gf = gfs[0]
-    parts = gf.getParticipantByEmail(request.POST["email"])
-    if parts == None:
-        return render(request, 'main/login.html', {"groupformer" : gf, 'error' : True})
-    return render(request,'main/response_screen.html') #Temporary until proper one added
     
+    if request.POST.get("email"):
+        # Validate the login
+        parts = gf.getParticipantByEmail(request.POST["email"])
+        if parts == None:
+            return render(request, 'main/login.html', {"groupformer" : gf, 'error' : True})
+        return render(request,'main/response_screen.html') #Temporary until proper one added
+        
+    # Log into the groupformer for the first time
+    return render(request, 'main/login.html', {"groupformer" : gf})
 
 def sample_groups(request, groupformer_id):
     # Create arbitrary sample groups for testing the front-end

--- a/app/groupformer/min_iteration2/views.py
+++ b/app/groupformer/min_iteration2/views.py
@@ -68,7 +68,10 @@ def validate_login(request, groupformer_id):
     if len(gfs) == 0:
         return render(request, 'main/loginerror.html')
     gf = gfs[0]
-    
+    parts = gf.getParticipantByEmail(request.POST["email"])
+    if parts == None:
+        return render(request, 'main/login.html', {"groupformer" : gf, 'error' : True})
+    return render(request,'main/response_screen.html') #Temporary until proper one added
     
 
 def sample_groups(request, groupformer_id):

--- a/app/groupformer/min_iteration2/views.py
+++ b/app/groupformer/min_iteration2/views.py
@@ -3,6 +3,7 @@ from django.http import JsonResponse
 from django.urls import reverse
 from django.views import generic
 from django.utils import timezone
+from django.shortcuts import redirect
 
 from dbtools.models import *
 
@@ -64,7 +65,7 @@ def login_group(request, groupformer_id):
         parts = gf.getParticipantByEmail(request.POST["email"])
         if parts == None:
             return render(request, 'main/login.html', {"groupformer" : gf, 'error' : True})
-        return render(request,'main/response_screen.html') #Temporary until proper one added
+        return redirect('../../response_screen/') #Temporary until proper one added
         
     # Log into the groupformer for the first time
     return render(request, 'main/login.html', {"groupformer" : gf})

--- a/app/groupformer/min_iteration2/views.py
+++ b/app/groupformer/min_iteration2/views.py
@@ -4,6 +4,8 @@ from django.urls import reverse
 from django.views import generic
 from django.utils import timezone
 
+from dbtools.models import *
+
 def response_screen(request):
     # Create arbitrary sample projects and attributes for testing the front-end
     projects = []
@@ -50,6 +52,15 @@ def groupformer_list(request):
         "section": "Section A"
     })
     return render(request, 'main/groupformer_list.html', {"groupformers": groupformers})
+
+def login_group(request, groupformer_id):
+    # Log into the groupformer
+    gfs = GroupFormer.objects.filter(pk=groupformer_id)
+    if len(gfs) == 0:
+        return render(request, 'main/loginerror.html')
+    gf = gfs[0]
+    print(repr(gf))
+    return render(request, 'main/login.html', {"groupformer" : gf})
 
 def sample_groups(request, groupformer_id):
     # Create arbitrary sample groups for testing the front-end


### PR DESCRIPTION
Resolves #30 by adding a login screen for participants to enter their email. While it doesn't currently send the Participant object to the response screen, it can when it's accepted

To test, run

    python manage.py test min_iteration2.tests.LoginScreenTest

from the normal directory. To run it directly, it is at

    .../min_iteration2/response_screen/<group former id>/login