### PR TITLE
Adds continuous deployment integration to the project

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+release: python manage.py migrate
+web: gunicorn groupformer.wsgi --log-file -

--- a/groupformer/settings.py
+++ b/groupformer/settings.py
@@ -125,8 +125,10 @@ USE_TZ = True
 import os
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 STATIC_URL = '/static/'
-import django_heroku
-django_heroku.settings(locals())
+if 'HEROKU' in os.environ:
+    import django_heroku
+    django_heroku.settings(locals())
+    DEBUG = False
 
 # CSRF Security
 CSRF_USE_SESSIONS = True

--- a/groupformer/settings.py
+++ b/groupformer/settings.py
@@ -122,8 +122,11 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.1/howto/static-files/
 
+import os
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 STATIC_URL = '/static/'
-
+import django_heroku
+django_heroku.settings(locals())
 
 # CSRF Security
 CSRF_USE_SESSIONS = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ pytz==2021.1
 selenium==3.141.0
 sqlparse==0.4.1
 urllib3==1.26.4
+gunicorn==20.1.0
+django_heroku==0.3.1

--- a/response_screen/views.py
+++ b/response_screen/views.py
@@ -32,7 +32,7 @@ def login_group(request, groupformer_id):
         parts = gf.getParticipantByEmail(request.POST["email"])
         if parts == None:
             return render(request, 'response_screen_main/login.html', {"groupformer": gf, 'error': True})
-        return redirect(reverse('reverse:response_screen', kwargs={"groupformer_id": gf.pk}))
+        return redirect(reverse('response_screen:response_screen', kwargs={"groupformer_id": gf.pk}))
 
     # Log into the groupformer for the first time
     return render(request, 'response_screen_main/login.html', {"groupformer": gf})


### PR DESCRIPTION
Closes #63 

Allows for the project to be accessed as it stands on 

    https://groupformer.herokuapp.com/

Currently pulls from the `continuous-deployment` branch, will be moved on Heroku to `develop` once this is merged in
Also fixes a bug that was unnoticed that resulted from #83 