### PR TITLE
Cleanup geckodriver instead of chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,22 @@
 # Groupformer
 A tool to make forming groups based on preference more efficient.
 
-1.  Install Python 3.8  
-2.  Install the requirments.txt file:
-   - `pip install -r requirments.txt` to install the requirments needed to run our application. 
-
-3. To run the following tests: 
- - `cd \app\GroupFormer`
- - `python manage.py test setup_screen`
- NOTE for running tests: You need to download the selenium webdriver and put it in your PATH variable.
-
- Download: https://chromedriver.chromium.org/downloads
- Make sure this matches your chrome version
- Update PATH Environment Variable:
- Windows:
- Save chromedriver.exe to a path such as C:\Program Files\Selenium
- Press the windows button and search 'advanced system settings'
- Click 'Environment Variables'
- Edit your User or System PATH variable adding the directory you chose
- Further Note: Currently an issue with Chrome v89 that will be fixed in v90 but is currently in beta.
- Selenium will spew some warning messages, but this doesn't effect the integration tests aside from
- clogging the terminal output.
- https://stackoverflow.com/questions/65080685/usb-usb-device-handle-win-cc1020-failed-to-read-descriptor-from-node-connectio
+1. Install Python 3.8  
+1. Install the requirments.txt file:
+   - `pip install -r requirments.txt` to install the requirments needed to run our application.
+1. To run the following tests:
+   - `cd \app\GroupFormer`
+   - `python manage.py test setup_screen`
  
- The requirements.txt reflects the Selenium version used to test the AJAX interaction within groupformer_list, and the form submission interaction within response_screen.
- The WebDriver used for the Selenium test is geckodriver, a Firefox webdriver.
- Tester must have Firefox installed and install the geckodriver executable and include its path on the system PATH to test the following:
+   NOTE for running tests: You need to download the selenium webdriver and put it in your PATH variable.
+   
+   The requirements.txt reflects the Selenium version used to test the AJAX interaction within groupformer_list, and the form submission interaction within response_screen.
+   The WebDriver used for the Selenium test is geckodriver, a Firefox webdriver. 
+   Tester must have Firefox installed and install the geckodriver executable ([link](https://github.com/mozilla/geckodriver/releases)) and include its path on the system PATH run out integration tests.
 
- To test the response_screen endpoint:
- (Displaying the GroupFormer projects, attributes and participants)
- - `python manage.py test min_iteration3.tests.MinIteration3ResponseScreenTests`
- (Testing form submission, input omission, form data receival validation)
- - `python manage.py test min_iteration3.tests.SeleniumResponseScreen`
- To test the groupformer_list endpoint:
- - `python manage.py test min_iteration3.tests.SeleniumGroupformerList`
+   Run all tests from the project root directory using:
+   
+   `python manage.py test`
 
- https://github.com/mozilla/geckodriver/releases
- 
- - `python manage.py test dbtools` will test the database and verify a user's email is an instance of the groupformer. 
- - `python manage.py test min_iteration2.tests.LoginScreenTest` - Login Screen testing, requires Selenium 
- 
-4. After running  you can look at the output in localhost:8000 in your browser by running the following commands 
- - `python manage.py runserver` will run the server on localhost at port 8000.
+1. After running  you can look at the output in localhost:8000 in your browser by running the following commands 
+   - `python manage.py runserver` will run the server on localhost at port 8000

--- a/dbtools/views.py
+++ b/dbtools/views.py
@@ -15,7 +15,7 @@ def verify_participant(request, group_former_id):
         #return code is 200 - since the view is rendered directly
         return render(request, 'dbtools/pdenied.html')
     # return code will be 302 since doing a redirect to the response screen
-    return HttpResponseRedirect(reverse('results_screen:response_screen'))
+    return HttpResponseRedirect(reverse('response_screen:response_screen', kwargs={'groupformer_id': group_former_id}))
 
 # Migrated from projects/
 

--- a/response_screen/tests.py
+++ b/response_screen/tests.py
@@ -171,7 +171,7 @@ class SeleniumResponseScreen(StaticLiveServerTestCase):
         gfs1 = gfs[1]['gf'].id
 
         # Test for the first groupformer object
-        self.selenium.get('%s%s' % (self.live_server_url, '/response_screen/response_screen/{}'.format(gfs1)))
+        self.selenium.get(self.live_server_url + reverse('response_screen:response_screen', kwargs={'groupformer_id': gfs1}))
         # Name and Email
         self.selenium.find_element_by_xpath("//input[@id='participantNameForm']").send_keys("Min Chon")
         self.selenium.find_element_by_xpath("//input[@id='participantEmailForm']").send_keys("minc1@umbc.edu")
@@ -207,7 +207,7 @@ class SeleniumResponseScreen(StaticLiveServerTestCase):
         gfs1 = gfs[1]['gf'].id
 
         # Test for the first groupformer object
-        self.selenium.get('%s%s' % (self.live_server_url, '/response_screen/response_screen/{}'.format(gfs1)))
+        self.selenium.get(self.live_server_url + reverse('response_screen:response_screen', kwargs={'groupformer_id': gfs1}))
         # Name and Email
         self.selenium.find_element_by_xpath("//input[@id='participantNameForm']").send_keys("Min Chon")
         self.selenium.find_element_by_xpath("//input[@id='participantEmailForm']").send_keys("minc1@umbc.edu")
@@ -243,7 +243,7 @@ class SeleniumResponseScreen(StaticLiveServerTestCase):
         gfs1 = gfs[1]['gf'].id
 
         # Test for the first groupformer object
-        self.selenium.get('%s%s' % (self.live_server_url, '/response_screen/response_screen/{}'.format(gfs1)))
+        self.selenium.get(self.live_server_url + reverse('response_screen:response_screen', kwargs={'groupformer_id': gfs1}))
         # Name and Email
 
         # Remove user info to test missing error
@@ -284,7 +284,7 @@ class SeleniumResponseScreen(StaticLiveServerTestCase):
         #########################################
         # Test for the first groupformer object #
         #########################################
-        self.selenium.get('%s%s' % (self.live_server_url, '/response_screen/response_screen/{}'.format(gfs1)))
+        self.selenium.get(self.live_server_url + reverse('response_screen:response_screen', kwargs={'groupformer_id': gfs1}))
         # Name and Email
         self.selenium.find_element_by_xpath("//input[@id='participantNameForm']").send_keys("Min Chon")
         self.selenium.find_element_by_xpath("//input[@id='participantEmailForm']").send_keys("minc1@umbc.edu")
@@ -337,7 +337,7 @@ class SeleniumResponseScreen(StaticLiveServerTestCase):
         ##########################################
         # Test for the second groupformer object #
         ##########################################
-        self.selenium.get('%s%s' % (self.live_server_url, '/response_screen/response_screen/{}'.format(gfs2)))
+        self.selenium.get(self.live_server_url + reverse('response_screen:response_screen', kwargs={'groupformer_id': gfs2}))
         # Name and Email
         self.selenium.find_element_by_xpath("//input[@id='participantNameForm']").send_keys("Bobby Bobberson")
         self.selenium.find_element_by_xpath("//input[@id='participantEmailForm']").send_keys("bobbybob@umbc.edu")
@@ -397,7 +397,7 @@ class LoginScreenTest(StaticLiveServerTestCase):
         super().tearDownClass()
 
     def test_login(self):
-        self.selenium.get('%s%s' % (self.live_server_url, '/response_screen/1/login'))
+        self.selenium.get(self.live_server_url + reverse('response_screen:login', kwargs={'groupformer_id': 1}))
 
         # No alert on first look
         with self.assertRaises(NoSuchElementException):
@@ -416,4 +416,4 @@ class LoginScreenTest(StaticLiveServerTestCase):
         submit.click()
 
         # Should be redirected to response screen
-        self.assertTrue(self.selenium.current_url.endswith("/response_screen/"))
+        self.assertTrue(self.selenium.current_url.endswith("/response_screen/1"))

--- a/response_screen/views.py
+++ b/response_screen/views.py
@@ -32,7 +32,7 @@ def login_group(request, groupformer_id):
         parts = gf.getParticipantByEmail(request.POST["email"])
         if parts == None:
             return render(request, 'response_screen_main/login.html', {"groupformer": gf, 'error': True})
-        return redirect(reverse('reverse:response_screen', kwargs={"groupformer_id": gf.pk}))
+        return redirect(reverse('response_screen:response_screen', kwargs={"groupformer_id": gf.pk}))
 
     # Log into the groupformer for the first time
     return render(request, 'response_screen_main/login.html', {"groupformer": gf})

--- a/results_screen/tests.py
+++ b/results_screen/tests.py
@@ -56,6 +56,7 @@ def create_all_samples():
     create_sample_participants(gfs)
     return gfs
 
+
 class SeleniumGroupformerList(LiveServerTestCase):
 
     @classmethod
@@ -79,14 +80,17 @@ class SeleniumGroupformerList(LiveServerTestCase):
         gfs1 = gfs[1]['gf'].id
         gfs2 = gfs[2]['gf'].id
 
+        even_gfs = gfs1 if (gfs1-1) % 2 == 0 else gfs2
+        odd_gfs = gfs2 if (gfs1-1) % 2 == 0 else gfs1
+
         self.selenium.get(self.live_server_url + reverse('results_screen:groupformer_list'))
-        first_groupformer = self.selenium.find_element_by_id("groupformer{}_submit".format(gfs1))
-        second_groupformer = self.selenium.find_element_by_id("groupformer{}_submit".format(gfs2))
+        first_groupformer = self.selenium.find_element_by_id("groupformer{}_submit".format(even_gfs))
+        second_groupformer = self.selenium.find_element_by_id("groupformer{}_submit".format(odd_gfs))
         first_groupformer.click()
         second_groupformer.click()
-        sleep(3)
-        first_groups = self.selenium.find_element_by_id("groupformer{}_groups".format(gfs1))
-        second_groups = self.selenium.find_element_by_id("groupformer{}_groups".format(gfs2))
+
+        first_groups = self.selenium.find_element_by_id("groupformer{}_groups".format(even_gfs))
+        second_groups = self.selenium.find_element_by_id("groupformer{}_groups".format(odd_gfs))
 
         self.assertTrue("A, B, C" in first_groups.get_attribute("innerHTML"))
         self.assertTrue("1, 2, 3" in first_groups.get_attribute("innerHTML"))

--- a/results_screen/tests.py
+++ b/results_screen/tests.py
@@ -1,5 +1,9 @@
 from django.test import TestCase
 from django.urls import reverse
+from django.contrib.staticfiles.testing import LiveServerTestCase
+from selenium.webdriver.firefox.webdriver import WebDriver
+from time import sleep
+
 from dbtools.models import *
 
 
@@ -52,31 +56,7 @@ def create_all_samples():
     create_sample_participants(gfs)
     return gfs
 
-class MinIteration2ResponseScreenTests(TestCase):
-    def test_displays_all_projects(self):
-        """
-        If the page shows all of the arbitrary project inputs (without backend) from views.py, then it passes
-        """
-        response = self.client.get(reverse('results_screen:response_screen'))
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "SomethingProject")
-        self.assertContains(response, "OtherProject")
-        self.assertContains(response, "Some description about something that has some substance about some of what something entails")
-
-    def test_displays_all_attributes(self):
-        """
-        If the page shows all of the arbitrary attribute inputs (without backend) from views.py, then it passes
-        """
-        response = self.client.get(reverse('results_screen:response_screen'))
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "How comfortable are you with front-end?")
-        self.assertContains(response, "How comfortable are you with back-end?")
-
-from django.contrib.staticfiles.testing import StaticLiveServerTestCase
-from selenium.webdriver.firefox.webdriver import WebDriver
-        
-
-class SeleniumGroupformerList(StaticLiveServerTestCase):
+class SeleniumGroupformerList(LiveServerTestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -99,11 +79,12 @@ class SeleniumGroupformerList(StaticLiveServerTestCase):
         gfs1 = gfs[1]['gf'].id
         gfs2 = gfs[2]['gf'].id
 
-        self.selenium.get('%s%s' % (self.live_server_url, '/response_screen/groupformer_list'))
+        self.selenium.get(self.live_server_url + reverse('results_screen:groupformer_list'))
         first_groupformer = self.selenium.find_element_by_id("groupformer{}_submit".format(gfs1))
         second_groupformer = self.selenium.find_element_by_id("groupformer{}_submit".format(gfs2))
         first_groupformer.click()
         second_groupformer.click()
+        sleep(3)
         first_groups = self.selenium.find_element_by_id("groupformer{}_groups".format(gfs1))
         second_groups = self.selenium.find_element_by_id("groupformer{}_groups".format(gfs2))
 

--- a/setup_screen/tests.py
+++ b/setup_screen/tests.py
@@ -49,7 +49,7 @@ class SetupScreenIntegrationTests(LiveServerTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.driver = webdriver.Chrome()
+        cls.driver = webdriver.Firefox()
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Resolves #82 by using the firefox geckodriver for selenium instead of Chrome for some tests.

Fixes some issues in the tests due to PR #83 that were not observable without geckodriver

No new tests were added as a result of these changes.